### PR TITLE
Backport of https://github.com/openhab/openhab/pull/1460

### DIFF
--- a/bundles/org.openhab.core.compat1x/src/main/java/org/openhab/core/library/types/ArithmeticGroupFunction.java
+++ b/bundles/org.openhab.core.compat1x/src/main/java/org/openhab/core/library/types/ArithmeticGroupFunction.java
@@ -57,7 +57,7 @@ public interface ArithmeticGroupFunction extends GroupFunction {
 		public State calculate(List<Item> items) {
 			if(items!=null && items.size()>0) {
 				for(Item item : items) {
-					if(!activeState.equals(item.getState())) {
+					if(!activeState.equals(item.getStateAs(activeState.getClass()))) {
 						return passiveState;
 					}
 				}
@@ -132,7 +132,7 @@ public interface ArithmeticGroupFunction extends GroupFunction {
 		public State calculate(List<Item> items) {	
 			if(items!=null) {
 				for(Item item : items) {
-					if(activeState.equals(item.getState())) {
+					if(activeState.equals(item.getStateAs(activeState.getClass()))) {
 						return activeState;
 					}
 				}


### PR DESCRIPTION
This allows group items who are not exactly the same base item to be included in logic operations, for example a dimmer can now be included in a group switch item.