### PR TITLE
removed lazy bundle activation to avoid circular dependencies

### DIFF
--- a/bundles/org.openhab.core.compat1x/META-INF/MANIFEST.MF
+++ b/bundles/org.openhab.core.compat1x/META-INF/MANIFEST.MF
@@ -105,4 +105,3 @@ Bundle-ClassPath: lib/jl1.0.1.jar,
  lib/jackson-core-asl-1.9.2.jar,
  lib/jackson-mapper-asl-1.9.2.jar
 Service-Component: OSGI-INF/*.xml
-Bundle-ActivationPolicy: lazy

--- a/bundles/org.openhab.core.compat1x/OSGI-INF/audioaction.xml
+++ b/bundles/org.openhab.core.compat1x/OSGI-INF/audioaction.xml
@@ -9,7 +9,7 @@
     http://www.eclipse.org/legal/epl-v10.html
 
 -->
-<scr:component xmlns:scr="http://www.osgi.org/xmlns/scr/v1.1.0" immediate="true" name="org.openhab.action.audio">
+<scr:component xmlns:scr="http://www.osgi.org/xmlns/scr/v1.1.0" immediate="false" name="org.openhab.action.audio">
    <implementation class="org.openhab.io.multimedia.actions.AudioActionService"/>
    <reference bind="setVoiceManager" cardinality="1..1" interface="org.eclipse.smarthome.core.voice.VoiceManager" name="VoiceManager" policy="static" unbind="unsetVoiceManager"/>
    <service>


### PR DESCRIPTION
This should finally fix https://github.com/openhab/openhab/issues/4604.

Signed-off-by: Kai Kreuzer <kai@openhab.org>